### PR TITLE
Fix CI cache annotations and image provenance arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-
-      - name: Cache Go modules & build cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          # setup-go caches the module + build cache itself; a separate
+          # actions/cache over the same paths makes tar fail to extract over
+          # already-restored files ("Cannot open: File exists").
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ docker-build-web: # @HELP builds web frontend Docker image for current platform
 .PHONY: docker-push-web
 docker-push-web: # @HELP pushes web frontend Docker image to registry
 	docker buildx build --platform linux/amd64,linux/arm64 \
+	  --provenance=false --sbom=false \
 	  --output "type=image,push=true" \
 	  --tag $(DOCKER_IMAGE)-web:$(VERSION) web/
 
@@ -152,6 +153,7 @@ docker-compose-up: # @HELP runs backend + frontend via Docker Compose
 .PHONY: docker-build-push
 docker-build-push: # @HELP builds and pushes multi-arch image (PDF_GENERATOR=wkhtmltopdf|chromedp)
 	docker buildx build --platform linux/amd64,linux/arm64 \
+	  --provenance=false --sbom=false \
 	  --target $(PDF_GENERATOR) \
 	  --build-arg VERSION=$(VERSION) \
 	  --build-arg BUILD_DATE=$(commit_timestamp) \
@@ -184,12 +186,14 @@ ensure-base: # @HELP builds the base images only if they are missing from the re
 .PHONY: base-build-push
 base-build-push: # @HELP builds and pushes the prebuilt runtime base images (wkhtmltopdf + chromedp)
 	docker buildx build --platform linux/amd64,linux/arm64 \
+	  --provenance=false --sbom=false \
 	  --target wkhtmltopdf \
 	  $(DOCKER_CACHE_ARGS) \
 	  --output "type=image,push=true" \
 	  --tag $(BASE_REF_WK) \
 	  -f Dockerfile.base .
 	docker buildx build --platform linux/amd64,linux/arm64 \
+	  --provenance=false --sbom=false \
 	  --target chromedp \
 	  $(DOCKER_CACHE_ARGS) \
 	  --output "type=image,push=true" \


### PR DESCRIPTION
Two CI/build hygiene fixes (no application code changes).

## 1. `Test` job "Cannot open: File exists" annotations
The `Test` job had a manual `actions/cache` step over `~/go/pkg/mod` + `~/.cache/go-build` — the same paths `actions/setup-go@v6` already caches. setup-go restored them first, then the manual step's `tar` failed to extract over the existing files, emitting ~10 `Cannot open: File exists` error annotations (benign, job stayed green). Removed the redundant step; setup-go's built-in cache handles it (as lint/vuln jobs already do).

## 2. `unknown/unknown` image architecture
buildx ≥0.11 attaches SLSA provenance/SBOM attestations by default on `--push`, which show up as an extra `unknown/unknown` platform entry in the manifest list. Added `--provenance=false --sbom=false` to the four multi-arch buildx commands in the Makefile (`docker-push-web`, `docker-build-push`, `base-build-push` ×2; `release` inherits via `docker-build-push`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)